### PR TITLE
add WAZO_TENANT_UUID to channelvars

### DIFF
--- a/etc/asterisk/ari.d/01-wazo.conf
+++ b/etc/asterisk/ari.d/01-wazo.conf
@@ -1,7 +1,7 @@
 [general]
 enabled = yes
 allowed_origins = *
-channelvars = WAZO_SWITCHBOARD_QUEUE,WAZO_SWITCHBOARD_HOLD
+channelvars = WAZO_SWITCHBOARD_QUEUE,WAZO_SWITCHBOARD_HOLD,WAZO_TENANT_UUID
 
 [xivo]
 type = user


### PR DESCRIPTION
reason: used by switchboard application